### PR TITLE
DEV-950 add support for wrapped mode on GIFs

### DIFF
--- a/render/board.go
+++ b/render/board.go
@@ -114,9 +114,8 @@ func (b *Board) addHazard(p *engine.Point) {
 }
 
 func getDirection(p engine.Point, nP engine.Point) string {
-	d := fmt.Sprintf("%d,%d", nP.X-p.X, p.Y-nP.Y)
-	switch d {
-	case "1,0":
+	// handle cases where we aren't wrapping around the board
+	if p.X+1 == nP.X {
 		return "right"
 	}
 

--- a/render/board.go
+++ b/render/board.go
@@ -37,22 +37,43 @@ func (b *Board) setSquare(p *engine.Point, s BoardSquare) {
 }
 
 func (b *Board) getDirection(p engine.Point, nP engine.Point) string {
-	d := fmt.Sprintf("%d,%d", nP.X-p.X, p.Y-nP.Y)
-	switch d {
-	case "1,0":
+	// handle cases where we aren't wrapping around the board
+	if p.X+1 == nP.X {
 		return "right"
-	case "0,1":
-		return "down"
-	case "-1,0":
+	}
+
+	if p.X-1 == nP.X {
 		return "left"
-	case "0,-1":
-		return "up"
-	case "0,0":
-		return "right"
-	default:
-		log.Errorf("Unable to deterine snake direction: %s", d)
+	}
+
+	if p.Y+1 == nP.Y {
 		return "up"
 	}
+
+	if p.Y-1 == nP.Y {
+		return "down"
+	}
+
+	// handle cases where we are wrapping around the board
+	if p.X > nP.X && nP.X == 0 {
+		return "right"
+	}
+
+	if p.X < nP.X && p.X == 0 {
+		return "left"
+	}
+
+	if p.Y > nP.Y && nP.Y == 0 {
+		return "up"
+	}
+
+	if p.Y < nP.Y && p.Y == 0 {
+		return "down"
+	}
+
+	// default to "up" when invalid moves are passed
+	log.Errorf("Unable to determine snake direction: %v to %v", p, nP)
+	return "up"
 }
 
 // pP = previous point, p = current point, nP next point.

--- a/render/board_internal_test.go
+++ b/render/board_internal_test.go
@@ -1,0 +1,36 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/BattlesnakeOfficial/exporter/engine"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDirection(t *testing.T) {
+
+	cases := []struct {
+		p1   engine.Point // initial point
+		p2   engine.Point // point moved to
+		want string       // direction of movement
+		desc string       // description of test case
+	}{
+		// easy cases
+		{p1: engine.Point{X: 3, Y: 3}, p2: engine.Point{X: 3, Y: 4}, want: "up", desc: "non-wrapped up"},
+		{p1: engine.Point{X: 3, Y: 3}, p2: engine.Point{X: 3, Y: 2}, want: "down", desc: "non-wrapped down"},
+		{p1: engine.Point{X: 3, Y: 3}, p2: engine.Point{X: 4, Y: 3}, want: "right", desc: "non-wrapped right"},
+		{p1: engine.Point{X: 3, Y: 3}, p2: engine.Point{X: 2, Y: 3}, want: "left", desc: "non-wrapped left"},
+
+		// wrapped cases
+		{p1: engine.Point{X: 1, Y: 10}, p2: engine.Point{X: 1, Y: 0}, want: "up", desc: "wrapped up"},
+		{p1: engine.Point{X: 1, Y: 0}, p2: engine.Point{X: 1, Y: 10}, want: "down", desc: "wrapped down"},
+		{p1: engine.Point{X: 0, Y: 4}, p2: engine.Point{X: 10, Y: 4}, want: "left", desc: "wrapped left"},
+		{p1: engine.Point{X: 10, Y: 0}, p2: engine.Point{X: 0, Y: 0}, want: "right", desc: "wrapped right"},
+	}
+
+	b := NewBoard(11, 11)
+	for _, tc := range cases {
+		got := b.getDirection(tc.p1, tc.p2)
+		assert.Equal(t, tc.want, got, tc.desc)
+	}
+}


### PR DESCRIPTION
Update gif rendering to properly display snakes that wrap around boards.

**Summary of Changes**

- update `getDirection` to handle wrapped moves
- add test coverage for all valid `getDirection` cases

I tested this on a few games that had snakes wrapping and it looks like this was all that was required to get the gifs to render correctly.

![example1](https://user-images.githubusercontent.com/969644/151683993-95c94848-85f5-4c00-93f7-e520f219fc23.gif)
![example2](https://user-images.githubusercontent.com/969644/151683995-91be11a2-29ae-44de-b3ab-976fe671f6a5.gif)

