### PR TITLE
DEV-946 add hazard rendering to GIF endpoint

### DIFF
--- a/engine/models.go
+++ b/engine/models.go
@@ -24,9 +24,10 @@ type Snake struct {
 }
 
 type GameFrame struct {
-	Turn   int     `json:"Turn"`
-	Food   []Point `json:"Food"`
-	Snakes []Snake `json:"Snakes"`
+	Turn    int     `json:"Turn"`
+	Food    []Point `json:"Food"`
+	Snakes  []Snake `json:"Snakes"`
+	Hazards []Point `json:"Hazards"`
 }
 
 type Game struct {

--- a/render/ascii.go
+++ b/render/ascii.go
@@ -40,7 +40,9 @@ func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
 			}
 
 			contents := board.getContents(x, y)
-			last := contents[len(contents)-1] // since ascii can't have overlapping items, we take the last thing on the square
+
+			// since ascii can't have overlapping items, we take the last thing on the square
+			last := contents[len(contents)-1]
 
 			// Don't render hazards when they overlap other things.
 			// It's more important to see those things than the hazard.

--- a/render/ascii.go
+++ b/render/ascii.go
@@ -14,6 +14,7 @@ const (
 	ASCIISnakeHead = "H"
 	ASCIISnakeBody = "O"
 	ASCIISnakeTail = "T"
+	ASCIIHazard    = "."
 )
 
 func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
@@ -30,7 +31,7 @@ func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
 		}
 		for x := 0; x < board.Width; x++ {
 			// empty squares
-			if len(board.getContents(x, y)) == 0 {
+			if board.getSquare(x, y) == nil {
 				_, err = fmt.Fprint(w, ASCIIEmpty)
 				if err != nil {
 					return err
@@ -40,6 +41,13 @@ func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
 
 			contents := board.getContents(x, y)
 			last := contents[len(contents)-1] // since ascii can't have overlapping items, we take the last thing on the square
+
+			// Don't render hazards when they overlap other things.
+			// It's more important to see those things than the hazard.
+			if last.Type == BoardSquareHazard && len(contents) > 1 {
+				last = contents[len(contents)-2]
+			}
+
 			switch last.Type {
 			case BoardSquareSnakeHead:
 				_, err := fmt.Fprint(w, ASCIISnakeHead)
@@ -53,6 +61,11 @@ func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
 				}
 			case BoardSquareSnakeTail:
 				_, err = fmt.Fprint(w, ASCIISnakeTail)
+				if err != nil {
+					return err
+				}
+			case BoardSquareHazard:
+				_, err = fmt.Fprint(w, ASCIIHazard)
 				if err != nil {
 					return err
 				}

--- a/render/ascii.go
+++ b/render/ascii.go
@@ -29,31 +29,38 @@ func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
 			return err
 		}
 		for x := 0; x < board.Width; x++ {
-			switch board.Squares[x][y].Content {
-			case BoardSquareSnakeHead:
-				_, err := fmt.Fprint(w, ASCIISnakeHead)
-				if err != nil {
-					return err
-				}
-			case BoardSquareSnakeBody:
-				_, err = fmt.Fprint(w, ASCIISnakeBody)
-				if err != nil {
-					return err
-				}
-			case BoardSquareSnakeTail:
-				_, err = fmt.Fprint(w, ASCIISnakeTail)
-				if err != nil {
-					return err
-				}
-			case BoardSquareFood:
-				_, err = fmt.Fprint(w, ASCIIFood)
-				if err != nil {
-					return err
-				}
-			case BoardSquareEmpty:
+			// empty squares
+			if len(board.getContents(x, y)) == 0 {
 				_, err = fmt.Fprint(w, ASCIIEmpty)
 				if err != nil {
 					return err
+				}
+				continue
+			}
+
+			// TODO: multiple content rendering isn't supported (i.e. hazard + snake or hazard + food)
+			for _, c := range board.getContents(x, y) {
+				switch c.Type {
+				case BoardSquareSnakeHead:
+					_, err := fmt.Fprint(w, ASCIISnakeHead)
+					if err != nil {
+						return err
+					}
+				case BoardSquareSnakeBody:
+					_, err = fmt.Fprint(w, ASCIISnakeBody)
+					if err != nil {
+						return err
+					}
+				case BoardSquareSnakeTail:
+					_, err = fmt.Fprint(w, ASCIISnakeTail)
+					if err != nil {
+						return err
+					}
+				case BoardSquareFood:
+					_, err = fmt.Fprint(w, ASCIIFood)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/render/ascii.go
+++ b/render/ascii.go
@@ -23,7 +23,7 @@ func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
 	if err != nil {
 		return err
 	}
-	for y := 0; y < board.Height; y++ {
+	for y := board.Height - 1; y >= 0; y-- {
 		_, err := fmt.Fprint(w, "|")
 		if err != nil {
 			return err
@@ -38,29 +38,28 @@ func GameFrameToASCII(w io.Writer, g *engine.Game, gf *engine.GameFrame) error {
 				continue
 			}
 
-			// TODO: multiple content rendering isn't supported (i.e. hazard + snake or hazard + food)
-			for _, c := range board.getContents(x, y) {
-				switch c.Type {
-				case BoardSquareSnakeHead:
-					_, err := fmt.Fprint(w, ASCIISnakeHead)
-					if err != nil {
-						return err
-					}
-				case BoardSquareSnakeBody:
-					_, err = fmt.Fprint(w, ASCIISnakeBody)
-					if err != nil {
-						return err
-					}
-				case BoardSquareSnakeTail:
-					_, err = fmt.Fprint(w, ASCIISnakeTail)
-					if err != nil {
-						return err
-					}
-				case BoardSquareFood:
-					_, err = fmt.Fprint(w, ASCIIFood)
-					if err != nil {
-						return err
-					}
+			contents := board.getContents(x, y)
+			last := contents[len(contents)-1] // since ascii can't have overlapping items, we take the last thing on the square
+			switch last.Type {
+			case BoardSquareSnakeHead:
+				_, err := fmt.Fprint(w, ASCIISnakeHead)
+				if err != nil {
+					return err
+				}
+			case BoardSquareSnakeBody:
+				_, err = fmt.Fprint(w, ASCIISnakeBody)
+				if err != nil {
+					return err
+				}
+			case BoardSquareSnakeTail:
+				_, err = fmt.Fprint(w, ASCIISnakeTail)
+				if err != nil {
+					return err
+				}
+			case BoardSquareFood:
+				_, err = fmt.Fprint(w, ASCIIFood)
+				if err != nil {
+					return err
 				}
 			}
 		}

--- a/render/board.go
+++ b/render/board.go
@@ -12,7 +12,6 @@ const (
 	BoardSquareSnakeBody
 	BoardSquareSnakeHead
 	BoardSquareSnakeTail
-	BoardSquareDeadSnake
 	BoardSquareHazard
 )
 

--- a/render/board.go
+++ b/render/board.go
@@ -15,6 +15,9 @@ const (
 	BoardSquareHazard
 )
 
+// ColorDeadSnake is the default hex colour used for displaying snakes that have died
+const ColorDeadSnake = "#cdcdcd"
+
 // BoardSquareContentType works like an enum.
 // It provides a restricted set of types of content that can be placed in a board square.
 type BoardSquareContentType int
@@ -162,7 +165,7 @@ func (b *Board) placeSnake(snake engine.Snake) {
 	// Death color
 	color := snake.Color
 	if snake.Death != nil {
-		color = "#cdcdcd"
+		color = ColorDeadSnake
 	}
 
 	for i, point := range snake.Body {

--- a/render/board.go
+++ b/render/board.go
@@ -39,26 +39,37 @@ type BoardSquare struct {
 type Board struct {
 	Width   int
 	Height  int
-	squares [][]BoardSquare
+	squares map[engine.Point]*BoardSquare
 }
 
+// getSquare gets the BoardSquare at the given coordinates.
+// It returns nil if the square is empty (or if the coordinate is out of bounds).
 func (b *Board) getSquare(x, y int) *BoardSquare {
-	// We are making the layout of the 2D array match the visual representation of the board
-	// Because the board starts at the bottom left, we have to invert the y-axis.
-	rowIdx := b.Height - 1 - y // invert y
-
-	// Also, when accessing 2D arrays, rows (y) are the first index
-	// and columns (x) are the second index
-	return &b.squares[rowIdx][x]
+	return b.squares[engine.Point{X: x, Y: y}]
 }
 
 func (b *Board) addContent(p *engine.Point, c BoardSquareContent) {
 	s := b.getSquare(p.X, p.Y)
+
+	// initialise squares for empty locations
+	if s == nil {
+		s = &BoardSquare{}
+		b.squares[*p] = s
+	}
+
 	s.Contents = append(s.Contents, c)
 }
 
+// getContents gets the contents of the board at the specified position.
+// It is safe to call for any position.
+// Empty squares will have an empty list.
 func (b Board) getContents(x, y int) []BoardSquareContent {
-	return b.getSquare(x, y).Contents
+	s := b.getSquare(x, y)
+	if s == nil {
+		return nil
+	}
+
+	return s.Contents
 }
 
 func (b *Board) addFood(p *engine.Point) {
@@ -190,13 +201,7 @@ func (b *Board) placeSnake(snake engine.Snake) {
 }
 
 func NewBoard(w int, h int) *Board {
-	b := Board{Width: w, Height: h}
-
-	b.squares = make([][]BoardSquare, h)
-	for i := range b.squares {
-		b.squares[i] = make([]BoardSquare, w)
-	}
-
+	b := Board{Width: w, Height: h, squares: make(map[engine.Point]*BoardSquare)}
 	return &b
 }
 

--- a/render/board.go
+++ b/render/board.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	BoardSquareEmpty     = 0 // Zero State (Default)
-	BoardSquareFood      = 1
-	BoardSquareSnakeBody = 2
-	BoardSquareSnakeHead = 3
-	BoardSquareSnakeTail = 4
-	BoardSquareDeadSnake = 5
+	BoardSquareEmpty BoardSquareContent = iota // Zero State (Default)
+	BoardSquareFood
+	BoardSquareSnakeBody
+	BoardSquareSnakeHead
+	BoardSquareSnakeTail
+	BoardSquareDeadSnake
+	BoardSquareHazard
 )
 
 type BoardSquareContent int
@@ -173,6 +174,11 @@ func GameFrameToBoard(g *engine.Game, gf *engine.GameFrame) *Board {
 		if snake.Death == nil {
 			board.placeSnake(snake)
 		}
+	}
+
+	// Fourth, place hazards
+	for _, point := range gf.Hazards {
+		board.setSquare(&point, BoardSquare{Content: BoardSquareHazard})
 	}
 
 	return board

--- a/render/board_internal_test.go
+++ b/render/board_internal_test.go
@@ -94,14 +94,14 @@ func TestPlaceSnake(t *testing.T) {
 	require.Len(t, c, 1, "there should only be a head here")
 	assert.Equal(t, BoardSquareSnakeHead, c[0].Type, "this should be a head")
 	assert.Equal(t, "up", c[0].Direction, "the head should be pointing up")
-	assert.Equal(t, "#cdcdcd", c[0].HexColor, "the head should have the dead snake colour")
+	assert.Equal(t, ColorDeadSnake, c[0].HexColor, "the head should have the dead snake colour")
 	assert.Equal(t, "regular", c[0].SnakeType, "the head should be default")
 
 	// BODY
 	c = b.getContents(5, 8)
 	require.Len(t, c, 1, "there should only be a body here")
 	assert.Equal(t, BoardSquareSnakeBody, c[0].Type, "this should be a body")
-	assert.Equal(t, "#cdcdcd", c[0].HexColor, "the body should have the dead snake colour")
+	assert.Equal(t, ColorDeadSnake, c[0].HexColor, "the body should have the dead snake colour")
 	assert.Equal(t, "", c[0].SnakeType, "the body should not have a customization")
 
 	// TAIL
@@ -109,6 +109,6 @@ func TestPlaceSnake(t *testing.T) {
 	require.Len(t, c, 1, "there should only be a tail here")
 	assert.Equal(t, BoardSquareSnakeTail, c[0].Type, "this should be a tail")
 	assert.Equal(t, "left", c[0].Direction, "the tail should be pointing left")
-	assert.Equal(t, "#cdcdcd", c[0].HexColor, "the tail should have the dead snake colour")
+	assert.Equal(t, ColorDeadSnake, c[0].HexColor, "the tail should have the dead snake colour")
 	assert.Equal(t, "regular", c[0].SnakeType, "the tail should be default")
 }

--- a/render/board_internal_test.go
+++ b/render/board_internal_test.go
@@ -36,3 +36,79 @@ func TestBoard(t *testing.T) {
 	b.addHazard(&engine.Point{X: 3, Y: 0})
 	assert.Equal(t, BoardSquareHazard, b.getContents(3, 0)[1].Type, "(3,0) should ALSO have hazard content")
 }
+
+func TestPlaceSnake(t *testing.T) {
+	b := NewBoard(11, 11)
+
+	t.Log("Placing an alive snake")
+	s := engine.Snake{
+		// define properties that matter to the board
+		Color: "#3B194D",
+		Body: []engine.Point{
+			{X: 0, Y: 0}, // head
+			{X: 0, Y: 1},
+			{X: 1, Y: 1}, // tail
+		},
+		Head: "beluga",
+		Tail: "rattle",
+	}
+	b.placeSnake(s)
+
+	// HEAD
+	c := b.getContents(0, 0)
+	require.Len(t, c, 1, "there should only be a head here")
+	assert.Equal(t, BoardSquareSnakeHead, c[0].Type, "this should be a head")
+	assert.Equal(t, "down", c[0].Direction, "the head should be pointing down")
+	assert.Equal(t, "#3B194D", c[0].HexColor, "the head should have the snake colour")
+	assert.Equal(t, "beluga", c[0].SnakeType, "the head should be customised")
+
+	// BODY
+	c = b.getContents(0, 1)
+	require.Len(t, c, 1, "there should only be a body here")
+	assert.Equal(t, BoardSquareSnakeBody, c[0].Type, "this should be a body")
+	assert.Equal(t, "#3B194D", c[0].HexColor, "the body should have the snake colour")
+	assert.Equal(t, "", c[0].SnakeType, "the body should not have a customization")
+
+	// TAIL
+	c = b.getContents(1, 1)
+	require.Len(t, c, 1, "there should only be a tail here")
+	assert.Equal(t, BoardSquareSnakeTail, c[0].Type, "this should be a tail")
+	assert.Equal(t, "right", c[0].Direction, "the tail should be pointing right")
+	assert.Equal(t, "#3B194D", c[0].HexColor, "the tail should have the snake colour")
+	assert.Equal(t, "rattle", c[0].SnakeType, "the tail should be customised")
+
+	t.Log("Placing a dead snake")
+	s = engine.Snake{
+		Death: &engine.Death{Cause: "", Turn: 10},
+		// define properties that matter to the board
+		Color: "#FFFFFF",
+		Body: []engine.Point{
+			{X: 5, Y: 9}, // head
+			{X: 5, Y: 8},
+			{X: 4, Y: 8}, // tail
+		},
+	}
+	b.placeSnake(s)
+
+	c = b.getContents(5, 9)
+	require.Len(t, c, 1, "there should only be a head here")
+	assert.Equal(t, BoardSquareSnakeHead, c[0].Type, "this should be a head")
+	assert.Equal(t, "up", c[0].Direction, "the head should be pointing up")
+	assert.Equal(t, "#cdcdcd", c[0].HexColor, "the head should have the dead snake colour")
+	assert.Equal(t, "regular", c[0].SnakeType, "the head should be default")
+
+	// BODY
+	c = b.getContents(5, 8)
+	require.Len(t, c, 1, "there should only be a body here")
+	assert.Equal(t, BoardSquareSnakeBody, c[0].Type, "this should be a body")
+	assert.Equal(t, "#cdcdcd", c[0].HexColor, "the body should have the dead snake colour")
+	assert.Equal(t, "", c[0].SnakeType, "the body should not have a customization")
+
+	// TAIL
+	c = b.getContents(4, 8)
+	require.Len(t, c, 1, "there should only be a tail here")
+	assert.Equal(t, BoardSquareSnakeTail, c[0].Type, "this should be a tail")
+	assert.Equal(t, "left", c[0].Direction, "the tail should be pointing left")
+	assert.Equal(t, "#cdcdcd", c[0].HexColor, "the tail should have the dead snake colour")
+	assert.Equal(t, "regular", c[0].SnakeType, "the tail should be default")
+}

--- a/render/board_internal_test.go
+++ b/render/board_internal_test.go
@@ -1,0 +1,41 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/BattlesnakeOfficial/exporter/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoard(t *testing.T) {
+	b := NewBoard(11, 11)
+
+	// ensure initial state is clean and correct
+	require.Equal(t, 11, b.Width)
+	require.Equal(t, 11, b.Height)
+	require.Len(t, b.squares, 11)
+	for y := 0; y < 11; y++ {
+		require.Len(t, b.squares[y], 11, "row %d should have length 11", y)
+		for x := 0; x < 11; x++ {
+			s := b.getSquare(x, y)
+			require.Len(t, s.Contents, 0, "board square (%d,%d) should be empty", x, y)
+		}
+	}
+
+	// ensure adding content works
+	b.addSnakeTail(&engine.Point{X: 0, Y: 0}, "#0acc33", "regular", "right")
+	assert.Equal(t, BoardSquareSnakeTail, b.getContents(0, 0)[0].Type, "(0,0) should have tail content")
+
+	b.addSnakeBody(&engine.Point{X: 1, Y: 0}, "#0acc33", "right", "none")
+	assert.Equal(t, BoardSquareSnakeBody, b.getContents(1, 0)[0].Type, "(1,0) should have body content")
+
+	b.addSnakeHead(&engine.Point{X: 2, Y: 0}, "#0acc33", "regular", "right")
+	assert.Equal(t, BoardSquareSnakeHead, b.getContents(2, 0)[0].Type, "(2,0) should have head content")
+
+	b.addFood(&engine.Point{X: 3, Y: 0})
+	assert.Equal(t, BoardSquareFood, b.getContents(3, 0)[0].Type, "(3,0) should have food content")
+
+	b.addHazard(&engine.Point{X: 3, Y: 0})
+	assert.Equal(t, BoardSquareHazard, b.getContents(3, 0)[1].Type, "(3,0) should ALSO have hazard content")
+}

--- a/render/board_internal_test.go
+++ b/render/board_internal_test.go
@@ -12,14 +12,11 @@ func TestBoard(t *testing.T) {
 	b := NewBoard(11, 11)
 
 	// ensure initial state is clean and correct
-	require.Equal(t, 11, b.Width)
-	require.Equal(t, 11, b.Height)
-	require.Len(t, b.squares, 11)
-	for y := 0; y < 11; y++ {
-		require.Len(t, b.squares[y], 11, "row %d should have length 11", y)
-		for x := 0; x < 11; x++ {
+	require.Len(t, b.squares, 0)
+	for x := 0; x < 11; x++ {
+		for y := 0; y < 11; y++ {
 			s := b.getSquare(x, y)
-			require.Len(t, s.Contents, 0, "board square (%d,%d) should be empty", x, y)
+			require.Nil(t, s, 0, "board square (%d,%d) should be empty", x, y)
 		}
 	}
 

--- a/render/board_test.go
+++ b/render/board_test.go
@@ -1,0 +1,68 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/BattlesnakeOfficial/exporter/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGameFrameToBoard(t *testing.T) {
+	g := engine.Game{
+		Width:  7,
+		Height: 7,
+	}
+	gf := engine.GameFrame{
+		Turn: 50,
+		Food: []engine.Point{{3, 3}},
+		Snakes: []engine.Snake{
+			// alive corner snake
+			{
+				Body: []engine.Point{{X: 0, Y: 0}, {X: 0, Y: 1}},
+			},
+			// expired dead snake (> 10 turns since death)
+			{
+				Death: &engine.Death{Cause: "", Turn: 12},
+				Body:  []engine.Point{{X: 2, Y: 0}, {X: 2, Y: 1}},
+			},
+			// recently dead snake
+			{
+				Death: &engine.Death{Cause: "", Turn: 48},
+				Body:  []engine.Point{{X: 4, Y: 2}, {X: 3, Y: 2}},
+			},
+		},
+		Hazards: []engine.Point{{0, 6}, {1, 6}, {2, 6}, {3, 6}, {4, 6}, {5, 6}, {6, 6}},
+	}
+	b := GameFrameToBoard(&g, &gf)
+	require.NotNil(t, b)
+	assert.Equal(t, 7, b.Width, "board width should match game")
+	assert.Equal(t, 7, b.Height, "board height should match game")
+	assert.Len(t, b.squares, 1+2+2+7) // 1 food, snake of 2, snake of 2, hazard of 7
+
+	// food
+	assert.Len(t, b.getContents(3, 3), 1, "food should be placed")
+	assert.Equal(t, BoardSquareFood, b.getContents(3, 3)[0].Type)
+
+	// expired dead snake
+	assert.Len(t, b.getContents(2, 0), 0, "expired snake shouldn't get placed")
+	assert.Len(t, b.getContents(2, 1), 0, "expired snake shouldn't get placed")
+
+	// non expired, dead snake
+	require.Len(t, b.getContents(4, 2), 1, "recently dead snake should be placed")
+	assert.Equal(t, BoardSquareSnakeHead, b.getContents(4, 2)[0].Type)
+	require.Len(t, b.getContents(3, 2), 1, "recently dead snake should be placed")
+	assert.Equal(t, BoardSquareSnakeTail, b.getContents(3, 2)[0].Type)
+
+	// alive snake
+	require.Len(t, b.getContents(0, 0), 1, "alive snake should be placed")
+	assert.Equal(t, BoardSquareSnakeHead, b.getContents(0, 0)[0].Type)
+	require.Len(t, b.getContents(0, 1), 1, "alive snake should be placed")
+	assert.Equal(t, BoardSquareSnakeTail, b.getContents(0, 1)[0].Type)
+
+	// hazard line
+	for i := 0; i < 7; i++ {
+		require.Len(t, b.getContents(i, 6), 1, "hazard (%d,6) should exist", i)
+		assert.Equal(t, BoardSquareHazard, b.getContents(i, 6)[0].Type)
+	}
+}

--- a/render/board_test.go
+++ b/render/board_test.go
@@ -15,7 +15,7 @@ func TestGameFrameToBoard(t *testing.T) {
 	}
 	gf := engine.GameFrame{
 		Turn: 50,
-		Food: []engine.Point{{3, 3}},
+		Food: []engine.Point{{X: 3, Y: 3}},
 		Snakes: []engine.Snake{
 			// alive corner snake
 			{
@@ -32,7 +32,7 @@ func TestGameFrameToBoard(t *testing.T) {
 				Body:  []engine.Point{{X: 4, Y: 2}, {X: 3, Y: 2}},
 			},
 		},
-		Hazards: []engine.Point{{0, 6}, {1, 6}, {2, 6}, {3, 6}, {4, 6}, {5, 6}, {6, 6}},
+		Hazards: []engine.Point{{X: 0, Y: 6}, {X: 1, Y: 6}, {X: 2, Y: 6}, {X: 3, Y: 6}, {X: 4, Y: 6}, {X: 5, Y: 6}, {X: 6, Y: 6}},
 	}
 	b := GameFrameToBoard(&g, &gf)
 	require.NotNil(t, b)

--- a/render/image.go
+++ b/render/image.go
@@ -317,7 +317,7 @@ func createBoardContext(b *Board) *gg.Context {
 	// Draw empty squares
 	for y := 0; y < b.Height; y++ {
 		for x := 0; x < b.Width; x++ {
-			if b.Squares[x][y].Content != BoardSquareSnakeBody {
+			if len(b.getContents(x, y)) == 0 {
 				drawEmptySquare(dc, x, y)
 			}
 		}
@@ -349,29 +349,25 @@ func drawBoard(b *Board) image.Image {
 
 	// Draw food and snakes over watermark
 	var snakeAsset string
-	for x, row := range b.Squares {
-		for y, square := range row {
-			switch square.Content {
-			case BoardSquareSnakeHead:
-				snakeAsset = fmt.Sprintf("heads/%s.png", square.SnakeType)
-				drawSnakeImage(snakeAsset, AssetFallbackHead, dc, x, y, square.HexColor, square.Direction)
-				drawGaps(dc, x, y, square.Direction, square.HexColor)
-			case BoardSquareSnakeBody:
-				drawSnakeBody(dc, x, y, square.HexColor, square.Corner)
-				drawGaps(dc, x, y, square.Direction, square.HexColor)
-			case BoardSquareSnakeTail:
-				snakeAsset = fmt.Sprintf("tails/%s.png", square.SnakeType)
-				drawSnakeImage(snakeAsset, AssetFallbackTail, dc, x, y, square.HexColor, square.Direction)
-			case BoardSquareFood:
-				drawFood(dc, x, y)
-			case BoardSquareHazard:
-				drawHazard(dc, x, y)
-			case BoardSquareEmpty:
-				// no-op
-			default:
-				// TODO: check with the Battlesnake team whether they want this logged...
-				// this could be pretty spammy, but it's also probably good to know when we don't handle new content types
-				// log.Warnf("Unhandled square content type: %d at (%d,%d)", square.Content, x, y)
+	for y := 0; y < b.Height; y++ {
+		for x := 0; x < b.Width; x++ {
+			for _, c := range b.getContents(x, y) {
+				switch c.Type {
+				case BoardSquareSnakeHead:
+					snakeAsset = fmt.Sprintf("heads/%s.png", c.SnakeType)
+					drawSnakeImage(snakeAsset, AssetFallbackHead, dc, x, y, c.HexColor, c.Direction)
+					drawGaps(dc, x, y, c.Direction, c.HexColor)
+				case BoardSquareSnakeBody:
+					drawSnakeBody(dc, x, y, c.HexColor, c.Corner)
+					drawGaps(dc, x, y, c.Direction, c.HexColor)
+				case BoardSquareSnakeTail:
+					snakeAsset = fmt.Sprintf("tails/%s.png", c.SnakeType)
+					drawSnakeImage(snakeAsset, AssetFallbackTail, dc, x, y, c.HexColor, c.Direction)
+				case BoardSquareFood:
+					drawFood(dc, x, y)
+				case BoardSquareHazard:
+					drawHazard(dc, x, y)
+				}
 			}
 		}
 	}

--- a/render/image.go
+++ b/render/image.go
@@ -136,11 +136,22 @@ func drawEmptySquare(dc *gg.Context, x int, y int) {
 }
 
 func drawFood(dc *gg.Context, x int, y int) {
-	dc.SetRGB255(255, 92, 117)
+	dc.SetRGBA255(255, 92, 117, 255)
 	dc.DrawCircle(
 		float64(x*SquareSizePixels+SquareSizePixels/2+BoardBorder),
 		float64(y*SquareSizePixels+SquareSizePixels/2+BoardBorder),
 		SquareFoodRadius,
+	)
+	dc.Fill()
+}
+
+func drawHazard(dc *gg.Context, x int, y int) {
+	dc.SetRGBA255(0, 0, 0, 102)
+	dc.DrawRectangle(
+		float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
+		float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
+		float64(SquareSizePixels-SquareBorderPixels*2),
+		float64(SquareSizePixels-SquareBorderPixels*2),
 	)
 	dc.Fill()
 }
@@ -353,6 +364,14 @@ func drawBoard(b *Board) image.Image {
 				drawSnakeImage(snakeAsset, AssetFallbackTail, dc, x, y, square.HexColor, square.Direction)
 			case BoardSquareFood:
 				drawFood(dc, x, y)
+			case BoardSquareHazard:
+				drawHazard(dc, x, y)
+			case BoardSquareEmpty:
+				// no-op
+			default:
+				// TODO: check with the Battlesnake team whether they want this logged...
+				// this could be pretty spammy, but it's also probably good to know when we don't handle new content types
+				// log.Warnf("Unhandled square content type: %d at (%d,%d)", square.Content, x, y)
 			}
 		}
 	}

--- a/render/image.go
+++ b/render/image.go
@@ -23,6 +23,9 @@ const (
 	SquareSizePixels         = 20
 	SquareBorderPixels       = 1
 	SquareFoodRadius         = SquareSizePixels / 3
+	ColorEmptySquare         = "#f0f0f0"
+	ColorFood                = "#ff5c75"
+	ColorHazard              = "#00000066"
 )
 
 var boardImageCache = make(map[string]image.Image)
@@ -125,7 +128,7 @@ func drawWatermark(dc *gg.Context) {
 }
 
 func drawEmptySquare(dc *gg.Context, bx int, by int) {
-	dc.SetRGB255(240, 240, 240)
+	dc.SetHexColor(ColorEmptySquare)
 	dc.DrawRectangle(
 		boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
 		boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
@@ -136,7 +139,7 @@ func drawEmptySquare(dc *gg.Context, bx int, by int) {
 }
 
 func drawFood(dc *gg.Context, bx int, by int) {
-	dc.SetRGBA255(255, 92, 117, 255)
+	dc.SetHexColor(ColorFood)
 	dc.DrawCircle(
 		boardXToDrawX(dc, bx)+SquareSizePixels/2+BoardBorder,
 		boardYToDrawY(dc, by)+SquareSizePixels/2+BoardBorder,
@@ -146,7 +149,7 @@ func drawFood(dc *gg.Context, bx int, by int) {
 }
 
 func drawHazard(dc *gg.Context, bx int, by int) {
-	dc.SetRGBA255(0, 0, 0, 102)
+	dc.SetHexColor(ColorHazard)
 	dc.DrawRectangle(
 		boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
 		boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,

--- a/render/image.go
+++ b/render/image.go
@@ -380,12 +380,13 @@ func boardXToDrawX(dc *gg.Context, x int) float64 {
 	return float64(x * SquareSizePixels)
 }
 
-// boardXToDrawY converts an x coordinate in "board space" to the x coordinate used by graphics.
+// boardYToDrawY converts a y coordinate in "board space" to the y coordinate used by graphics.
 // More specifically, it assumes the board coordinates are the indexes of squares and it returns the upper left
 // corner for that square.
 func boardYToDrawY(dc *gg.Context, y int) float64 {
 	// Note: the Battlesnake board coordinates have (0,0) at the bottom left
 	// so we need to flip the y-axis to convert to the graphics, which follows the convention
 	// of (0,0) being the top left.
+	// ALSO, there is a gap at the bottom and some borders that need to get offset.
 	return float64((dc.Height() - BoardBorderBottom - BoardBorder*2 - SquareSizePixels) - (y * SquareSizePixels)) // flip!
 }

--- a/render/image.go
+++ b/render/image.go
@@ -347,27 +347,26 @@ func drawBoard(b *Board) image.Image {
 
 	// Draw food and snakes over watermark
 	var snakeAsset string
-	for y := 0; y < b.Height; y++ {
-		for x := 0; x < b.Width; x++ {
-			for _, c := range b.getContents(x, y) {
-				switch c.Type {
-				case BoardSquareSnakeHead:
-					snakeAsset = fmt.Sprintf("heads/%s.png", c.SnakeType)
-					drawSnakeImage(snakeAsset, AssetFallbackHead, dc, x, y, c.HexColor, c.Direction)
-					drawGaps(dc, x, y, c.Direction, c.HexColor)
-				case BoardSquareSnakeBody:
-					drawSnakeBody(dc, x, y, c.HexColor, c.Corner)
-					drawGaps(dc, x, y, c.Direction, c.HexColor)
-				case BoardSquareSnakeTail:
-					snakeAsset = fmt.Sprintf("tails/%s.png", c.SnakeType)
-					drawSnakeImage(snakeAsset, AssetFallbackTail, dc, x, y, c.HexColor, c.Direction)
-				case BoardSquareFood:
-					drawFood(dc, x, y)
-				case BoardSquareHazard:
-					drawHazard(dc, x, y)
-				}
+	for p, s := range b.squares { // cool, we can iterate ONLY the non-empty squares!
+		for _, c := range s.Contents {
+			switch c.Type {
+			case BoardSquareSnakeHead:
+				snakeAsset = fmt.Sprintf("heads/%s.png", c.SnakeType)
+				drawSnakeImage(snakeAsset, AssetFallbackHead, dc, p.X, p.Y, c.HexColor, c.Direction)
+				drawGaps(dc, p.X, p.Y, c.Direction, c.HexColor)
+			case BoardSquareSnakeBody:
+				drawSnakeBody(dc, p.X, p.Y, c.HexColor, c.Corner)
+				drawGaps(dc, p.X, p.Y, c.Direction, c.HexColor)
+			case BoardSquareSnakeTail:
+				snakeAsset = fmt.Sprintf("tails/%s.png", c.SnakeType)
+				drawSnakeImage(snakeAsset, AssetFallbackTail, dc, p.X, p.Y, c.HexColor, c.Direction)
+			case BoardSquareFood:
+				drawFood(dc, p.X, p.Y)
+			case BoardSquareHazard:
+				drawHazard(dc, p.X, p.Y)
 			}
 		}
+
 	}
 
 	return dc.Image()

--- a/render/image.go
+++ b/render/image.go
@@ -124,39 +124,39 @@ func drawWatermark(dc *gg.Context) {
 	dc.DrawImageAnchored(watermarkImage, dc.Width()/2, dc.Height()/2, 0.5, 0.5)
 }
 
-func drawEmptySquare(dc *gg.Context, x int, y int) {
+func drawEmptySquare(dc *gg.Context, bx int, by int) {
 	dc.SetRGB255(240, 240, 240)
 	dc.DrawRectangle(
-		float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-		float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-		float64(SquareSizePixels-SquareBorderPixels*2),
-		float64(SquareSizePixels-SquareBorderPixels*2),
+		boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+		boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+		SquareSizePixels-SquareBorderPixels*2,
+		SquareSizePixels-SquareBorderPixels*2,
 	)
 	dc.Fill()
 }
 
-func drawFood(dc *gg.Context, x int, y int) {
+func drawFood(dc *gg.Context, bx int, by int) {
 	dc.SetRGBA255(255, 92, 117, 255)
 	dc.DrawCircle(
-		float64(x*SquareSizePixels+SquareSizePixels/2+BoardBorder),
-		float64(y*SquareSizePixels+SquareSizePixels/2+BoardBorder),
+		boardXToDrawX(dc, bx)+SquareSizePixels/2+BoardBorder,
+		boardYToDrawY(dc, by)+SquareSizePixels/2+BoardBorder,
 		SquareFoodRadius,
 	)
 	dc.Fill()
 }
 
-func drawHazard(dc *gg.Context, x int, y int) {
+func drawHazard(dc *gg.Context, bx int, by int) {
 	dc.SetRGBA255(0, 0, 0, 102)
 	dc.DrawRectangle(
-		float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-		float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-		float64(SquareSizePixels-SquareBorderPixels*2),
-		float64(SquareSizePixels-SquareBorderPixels*2),
+		boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+		boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+		SquareSizePixels-SquareBorderPixels*2,
+		SquareSizePixels-SquareBorderPixels*2,
 	)
 	dc.Fill()
 }
 
-func drawSnakeImage(filename string, fallbackFilename string, dc *gg.Context, x int, y int, hexColor string, direction string) {
+func drawSnakeImage(filename string, fallbackFilename string, dc *gg.Context, bx int, by int, hexColor string, direction string) {
 	var rotation int
 	switch direction {
 	case "right":
@@ -179,10 +179,10 @@ func drawSnakeImage(filename string, fallbackFilename string, dc *gg.Context, x 
 
 	dst := dc.Image().(draw.Image)
 	dstRect := image.Rect(
-		x*SquareSizePixels+SquareBorderPixels+BoardBorder,
-		y*SquareSizePixels+SquareBorderPixels+BoardBorder,
-		(x+1)*SquareSizePixels-SquareBorderPixels+BoardBorder,
-		(y+1)*SquareSizePixels-SquareBorderPixels+BoardBorder,
+		int(boardXToDrawX(dc, bx))+SquareBorderPixels+BoardBorder,
+		int(boardYToDrawY(dc, by))+SquareBorderPixels+BoardBorder,
+		int(boardXToDrawX(dc, bx+1))-SquareBorderPixels+BoardBorder,
+		int(boardYToDrawY(dc, by-1))-SquareBorderPixels+BoardBorder,
 	)
 
 	srcImage := &image.Uniform{parseHexColor(hexColor)}
@@ -190,68 +190,68 @@ func drawSnakeImage(filename string, fallbackFilename string, dc *gg.Context, x 
 	draw.DrawMask(dst, dstRect, srcImage, image.Point{}, maskImage, image.Point{}, draw.Over)
 }
 
-func drawSnakeBody(dc *gg.Context, x int, y int, hexColor, corner string) {
+func drawSnakeBody(dc *gg.Context, bx int, by int, hexColor, corner string) {
 	dc.SetHexColor(hexColor)
 	if corner == "none" {
 		dc.DrawRectangle(
-			float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64(SquareSizePixels-SquareBorderPixels*2),
-			float64(SquareSizePixels-SquareBorderPixels*2),
+			boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+			boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+			SquareSizePixels-SquareBorderPixels*2,
+			SquareSizePixels-SquareBorderPixels*2,
 		)
 	} else {
 		dc.DrawRoundedRectangle(
-			float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64(SquareSizePixels-SquareBorderPixels*2),
-			float64(SquareSizePixels-SquareBorderPixels*2),
-			float64(SquareSizePixels/2),
+			boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+			boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+			SquareSizePixels-SquareBorderPixels*2,
+			SquareSizePixels-SquareBorderPixels*2,
+			SquareSizePixels/2,
 		)
 		if strings.HasPrefix(corner, "bottom") {
 			dc.DrawRectangle(
-				float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-				float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-				float64(SquareSizePixels-SquareBorderPixels*2),
-				float64(SquareSizePixels/2),
+				boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+				boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+				SquareSizePixels-SquareBorderPixels*2,
+				SquareSizePixels/2,
 			)
 			if strings.HasSuffix(corner, "left") {
 				dc.DrawRectangle(
-					float64(x*SquareSizePixels+SquareSizePixels/2+BoardBorder),
-					float64(y*SquareSizePixels+SquareBorderPixels+SquareSizePixels/2+BoardBorder),
-					float64(SquareSizePixels/2-SquareBorderPixels),
-					float64(SquareSizePixels/2-SquareBorderPixels*2),
+					boardXToDrawX(dc, bx)+SquareSizePixels/2+BoardBorder,
+					boardYToDrawY(dc, by)+SquareBorderPixels+SquareSizePixels/2+BoardBorder,
+					SquareSizePixels/2-SquareBorderPixels,
+					SquareSizePixels/2-SquareBorderPixels*2,
 				)
 			}
 			if strings.HasSuffix(corner, "right") {
 				dc.DrawRectangle(
-					float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-					float64(y*SquareSizePixels+SquareBorderPixels+SquareSizePixels/2+BoardBorder),
-					float64(SquareSizePixels/2-SquareBorderPixels*2),
-					float64(SquareSizePixels/2-SquareBorderPixels*2),
+					boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+					boardYToDrawY(dc, by)+SquareBorderPixels+SquareSizePixels/2+BoardBorder,
+					SquareSizePixels/2-SquareBorderPixels*2,
+					SquareSizePixels/2-SquareBorderPixels*2,
 				)
 			}
 		}
 		if strings.HasPrefix(corner, "top") {
 			dc.DrawRectangle(
-				float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-				float64(y*SquareSizePixels+SquareBorderPixels+SquareSizePixels/2+BoardBorder),
-				float64(SquareSizePixels-SquareBorderPixels*2),
-				float64(SquareSizePixels/2),
+				boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+				boardYToDrawY(dc, by)+SquareBorderPixels+SquareSizePixels/2+BoardBorder,
+				SquareSizePixels-SquareBorderPixels*2,
+				SquareSizePixels/2,
 			)
 			if strings.HasSuffix(corner, "left") {
 				dc.DrawRectangle(
-					float64(x*SquareSizePixels+SquareSizePixels/2+SquareBorderPixels+BoardBorder),
-					float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-					float64(SquareSizePixels/2-SquareBorderPixels*2),
-					float64(SquareSizePixels/2-SquareBorderPixels*2),
+					boardXToDrawX(dc, bx)+SquareSizePixels/2+SquareBorderPixels+BoardBorder,
+					boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+					SquareSizePixels/2-SquareBorderPixels*2,
+					SquareSizePixels/2-SquareBorderPixels*2,
 				)
 			}
 			if strings.HasSuffix(corner, "right") {
 				dc.DrawRectangle(
-					float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-					float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-					float64(SquareSizePixels/2-SquareBorderPixels*2),
-					float64(SquareSizePixels/2-SquareBorderPixels*2),
+					boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+					boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+					SquareSizePixels/2-SquareBorderPixels*2,
+					SquareSizePixels/2-SquareBorderPixels*2,
 				)
 			}
 		}
@@ -259,36 +259,36 @@ func drawSnakeBody(dc *gg.Context, x int, y int, hexColor, corner string) {
 	dc.Fill()
 }
 
-func drawGaps(dc *gg.Context, x, y int, direction, hexColor string) {
+func drawGaps(dc *gg.Context, bx, by int, direction, hexColor string) {
 	dc.SetHexColor(hexColor)
 	switch direction {
 	case "up":
 		dc.DrawRectangle(
-			float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64((y+1)*SquareSizePixels-SquareBorderPixels+BoardBorder),
-			float64(SquareSizePixels-SquareBorderPixels*2),
-			float64(SquareBorderPixels*2),
+			boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+			boardYToDrawY(dc, by-1)-SquareBorderPixels+BoardBorder,
+			SquareSizePixels-SquareBorderPixels*2,
+			SquareBorderPixels*2,
 		)
 	case "down":
 		dc.DrawRectangle(
-			float64(x*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64(y*SquareSizePixels-SquareBorderPixels+BoardBorder),
-			float64(SquareSizePixels-SquareBorderPixels*2),
-			float64(SquareBorderPixels*2),
+			boardXToDrawX(dc, bx)+SquareBorderPixels+BoardBorder,
+			boardYToDrawY(dc, by)-SquareBorderPixels+BoardBorder,
+			SquareSizePixels-SquareBorderPixels*2,
+			SquareBorderPixels*2,
 		)
 	case "right":
 		dc.DrawRectangle(
-			float64(x*SquareSizePixels-SquareBorderPixels+BoardBorder),
-			float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64(SquareBorderPixels*2),
-			float64(SquareSizePixels-SquareBorderPixels*2),
+			boardXToDrawX(dc, bx)-SquareBorderPixels+BoardBorder,
+			boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+			SquareBorderPixels*2,
+			SquareSizePixels-SquareBorderPixels*2,
 		)
 	case "left":
 		dc.DrawRectangle(
-			float64((x+1)*SquareSizePixels-SquareBorderPixels+BoardBorder),
-			float64(y*SquareSizePixels+SquareBorderPixels+BoardBorder),
-			float64(SquareBorderPixels*2),
-			float64(SquareSizePixels-SquareBorderPixels*2),
+			boardXToDrawX(dc, bx+1)-SquareBorderPixels+BoardBorder,
+			boardYToDrawY(dc, by)+SquareBorderPixels+BoardBorder,
+			SquareBorderPixels*2,
+			SquareSizePixels-SquareBorderPixels*2,
 		)
 	}
 	dc.Fill()
@@ -317,9 +317,7 @@ func createBoardContext(b *Board) *gg.Context {
 	// Draw empty squares
 	for y := 0; y < b.Height; y++ {
 		for x := 0; x < b.Width; x++ {
-			if len(b.getContents(x, y)) == 0 {
-				drawEmptySquare(dc, x, y)
-			}
+			drawEmptySquare(dc, x, y)
 		}
 	}
 
@@ -373,4 +371,21 @@ func drawBoard(b *Board) image.Image {
 	}
 
 	return dc.Image()
+}
+
+// boardXToDrawX converts an x coordinate in "board space" to the x coordinate used by graphics.
+// More specifically, it assumes the board coordinates are the indexes of squares and it returns the upper left
+// corner for that square.
+func boardXToDrawX(dc *gg.Context, x int) float64 {
+	return float64(x * SquareSizePixels)
+}
+
+// boardXToDrawY converts an x coordinate in "board space" to the x coordinate used by graphics.
+// More specifically, it assumes the board coordinates are the indexes of squares and it returns the upper left
+// corner for that square.
+func boardYToDrawY(dc *gg.Context, y int) float64 {
+	// Note: the Battlesnake board coordinates have (0,0) at the bottom left
+	// so we need to flip the y-axis to convert to the graphics, which follows the convention
+	// of (0,0) being the top left.
+	return float64((dc.Height() - BoardBorderBottom - BoardBorder*2 - SquareSizePixels) - (y * SquareSizePixels)) // flip!
 }


### PR DESCRIPTION
This PR adds support for hazard gif rendering

**Summary of Changes**
- The `Board` data structure was changed to allow multiple contents in a square (necessary to support rendering hazards overlapping food/snakes)
- The `Board` data structure was changed to reduce cognitive load / improve maintainability
- Added some new placement methods (e.g. `addHazard`, `addFood` etc...)
- Cleaned up a few things (unused constants, naming, comments)
- Lots of new unit test coverage

**Before/After Examples**

[92bbd84f-5373-45c9-a3db-ec9ba61d55e3](https://play.battlesnake.com/g/92bbd84f-5373-45c9-a3db-ec9ba61d55e3/)

**Before**
![before](https://user-images.githubusercontent.com/969644/151864415-a05b76b9-67b0-4f1e-8aef-c052159a7bd6.gif)

**After**
![after](https://user-images.githubusercontent.com/969644/151864433-390f68a8-ed8d-4c88-8c3b-f5141600f5bb.gif)

[c9240fa7-04bd-4424-b591-071bc5370b9c](https://play.battlesnake.com/g/c9240fa7-04bd-4424-b591-071bc5370b9c/)

**Before**
![before](https://user-images.githubusercontent.com/969644/151864874-9860fc1c-9e45-42f1-aaef-c132c71ed3a9.gif)

**After**
![after](https://user-images.githubusercontent.com/969644/151864903-c3e7b891-846b-4617-9f10-78e388287350.gif)
