### PR TITLE
FIX: body overlap with tail rendering bug

### DIFF
--- a/render/board.go
+++ b/render/board.go
@@ -130,8 +130,8 @@ func (b Board) removeIfExists(x, y int, t BoardSquareContentType) {
 	}
 
 	// more than one item, we need to update the slice
-	// this is using the "append based removal" strategy which re-uses the slice
-	// effectively, it undoes the append
+	// this is using the "append based removal" strategy
+	// which re-uses the underlying slice
 	s.Contents = append(s.Contents[:foundIdx], s.Contents[foundIdx+1:]...)
 }
 


### PR DESCRIPTION
Fixed by removing body content when tail overlaps (happens when eating)

**BEFORE**
![d5247820-8ede-44f5-be67-cc0a2261b785](https://user-images.githubusercontent.com/969644/154856392-b9c62b0a-c425-4e8d-a121-65e76bb359dc.gif)


**AFTER**
![game2](https://user-images.githubusercontent.com/969644/154856399-fd151fdc-2ff0-486a-8982-231f0cf43e85.gif)

Note: I considered refactoring the game board with an alternative implementation that would use a map instead of a slice to store the contents. The key of this map could be something like a "z-index" or whatever we want to call a sort of uniqueness category/layer for certain types of content. Body/Tail/Head could all share a key so that whenever one is placed the other would be overwritten. Hazard would then be in another "layer" and would not get replaced. Not sure what would make sense for food in that scenario. Ultimately I decided against the refactor mainly for YAGNI reasons. This bug was a rare edge case and generally the game board doesn't overlap things that shouldn't co-exist. I think the simpler solution of handling the specific case of tail/body overlap is more pragmatic. We can revisit later if this proves not to be true.
