### PR TITLE
DEV 1803: PNG endpoint for snake avatars

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -38,8 +38,8 @@ func handleVersion(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, version)
 }
 
-var reAvatarParams = regexp.MustCompile(`^/(?:[a-z-]{1,32}:[A-Za-z-0-9#]{1,32}/)*(?P<width>[0-9]{2,4})x(?P<height>[0-9]{2,4}).(?P<ext>[a-z]{3,4})$`)
-var reAvatarCustomizations = regexp.MustCompile(`(?P<key>[a-z-]{1,32}):(?P<value>[A-Za-z-0-9#]{1,32})`)
+var reAvatarParams = regexp.MustCompile(`^/(?:[a-z-]{1,32}:[A-Za-z-0-9#]{0,32}/)*(?P<width>[0-9]{2,4})x(?P<height>[0-9]{2,4}).(?P<ext>[a-z]{3,4})$`)
+var reAvatarCustomizations = regexp.MustCompile(`(?P<key>[a-z-]{1,32}):(?P<value>[A-Za-z-0-9#]{0,32})`)
 
 func handleAvatar(w http.ResponseWriter, r *http.Request) {
 	subPath := strings.TrimPrefix(r.URL.Path, "/avatars")
@@ -77,6 +77,10 @@ func handleAvatar(w http.ResponseWriter, r *http.Request) {
 	reCustomizationResults := reAvatarCustomizations.FindAllStringSubmatch(subPath, -1)
 	for _, match := range reCustomizationResults {
 		cKey, cValue := match[1], match[2]
+		if cValue == "" {
+			// ignore empty values
+			continue
+		}
 		switch cKey {
 		case "head":
 			avatarSettings.HeadSVG, err = media.GetHeadSVG(cValue)

--- a/http/handlers_test.go
+++ b/http/handlers_test.go
@@ -35,6 +35,7 @@ func TestHandlerAvatar_OK(t *testing.T) {
 	}{
 		{"/200x100.svg", "image/svg+xml"},
 		{"/head:beluga/500x100.svg", "image/svg+xml"},
+		{"/head:/tail:/color:/500x100.svg", "image/svg+xml"},
 		{"/head:beluga/tail:fish/color:%2331688e/500x100.svg", "image/svg+xml"},
 		{"/head:beluga/tail:fish/color:%23FfEeCc/500x100.svg", "image/svg+xml"},
 		{"/head:beluga/tail:fish/color:%23FfEeCc/500x100.png", "image/png"},
@@ -64,16 +65,17 @@ func TestHandleAvatar_BadRequest(t *testing.T) {
 		"/500x99999.svg", // Invalid extension
 
 		"/color:00FF00/500x100.svg", // Invalid color value
-		"/head:/500x100.svg",        // Missing value
 		"/HEAD:default/500x100.svg", // Invalid characters
 		"/barf:true/500x100.svg",    // Unrecognized param
 
 	}
 
 	for _, path := range badRequestPaths {
-		req, res := fixtures.TestRequest(t, "GET", fmt.Sprintf("http://localhost/avatars%s", path), nil)
-		server.router.ServeHTTP(res, req)
-		require.Equal(t, http.StatusBadRequest, res.Code)
+		t.Run(path, func(t *testing.T) {
+			req, res := fixtures.TestRequest(t, "GET", fmt.Sprintf("http://localhost/avatars%s", path), nil)
+			server.router.ServeHTTP(res, req)
+			require.Equal(t, http.StatusBadRequest, res.Code)
+		})
 	}
 }
 

--- a/http/handlers_test.go
+++ b/http/handlers_test.go
@@ -29,15 +29,20 @@ func TestHandleVersion(t *testing.T) {
 func TestHandlerAvatar_OK(t *testing.T) {
 	server := NewServer()
 
-	for _, path := range []string{
-		"/200x100.svg",
-		"/head:beluga/500x100.svg",
-		"/head:beluga/tail:fish/color:%2331688e/500x100.svg",
-		"/head:beluga/tail:fish/color:%23FfEeCc/500x100.svg",
+	for _, test := range []struct {
+		path        string
+		contentType string
+	}{
+		{"/200x100.svg", "image/svg+xml"},
+		{"/head:beluga/500x100.svg", "image/svg+xml"},
+		{"/head:beluga/tail:fish/color:%2331688e/500x100.svg", "image/svg+xml"},
+		{"/head:beluga/tail:fish/color:%23FfEeCc/500x100.svg", "image/svg+xml"},
+		{"/head:beluga/tail:fish/color:%23FfEeCc/500x100.png", "image/png"},
 	} {
-		req, res := fixtures.TestRequest(t, "GET", fmt.Sprintf("http://localhost/avatars%s", path), nil)
+		req, res := fixtures.TestRequest(t, "GET", fmt.Sprintf("http://localhost/avatars%s", test.path), nil)
 		server.router.ServeHTTP(res, req)
-		require.Equal(t, http.StatusOK, res.Code, path)
+		require.Equal(t, http.StatusOK, res.Code, test.path)
+		require.Equal(t, res.Result().Header.Get("content-type"), test.contentType)
 	}
 }
 
@@ -55,7 +60,7 @@ func TestHandleAvatar_BadRequest(t *testing.T) {
 		"/100x1.svg",     // Invalid dimension
 		"/abcx100.svg",   // Missing dimension
 		"/100xqwer.svg",  // Missing dimension
-		"/500x100.png",   // Invalid extension
+		"/500x100.zip",   // Invalid extension
 		"/500x99999.svg", // Invalid extension
 
 		"/color:00FF00/500x100.svg", // Invalid color value


### PR DESCRIPTION
The conversion from SVG to PNG is triggered by the extension, e.g.
```
/avatars/head:alligator/tail:beach-puffin/color:%23ff33cc/300x100.png
```
