### PR TITLE
DEV 2240: Serve individual customizations from exporter

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -35,6 +35,9 @@ var allowedPixelsPerSquare = []int{10, 20, 30, 40}
 var errBadRequest = fmt.Errorf("bad request")
 var errBadColor = fmt.Errorf("color parameter should have the format #FFFFFF")
 
+var reCustomizationParam = regexp.MustCompile(`^[A-Za-z-0-9#]{1,32}$`)
+var reColorParam = regexp.MustCompile(`^#?[A-Fa-f0-9]{6}$`)
+
 func handleVersion(w http.ResponseWriter, r *http.Request) {
 	version := os.Getenv("APP_VERSION")
 	if len(version) == 0 {
@@ -107,7 +110,7 @@ func handleAvatar(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		case "color":
-			if len(cValue) != 7 || string(cValue[0]) != "#" {
+			if !reColorParam.MatchString(cValue) {
 				handleBadRequest(w, r, errBadRequest)
 				return
 			}
@@ -147,8 +150,6 @@ func handleAvatar(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, avatarSVG)
 }
 
-var reCustomizationParam = regexp.MustCompile(`^[A-Za-z-0-9#]{1,32}$`)
-
 func handleCustomization(w http.ResponseWriter, r *http.Request) {
 	customizationType := pat.Param(r, "type")
 	customizationName := pat.Param(r, "name")
@@ -172,7 +173,7 @@ func handleCustomization(w http.ResponseWriter, r *http.Request) {
 	var customizationColor color.Color = color.Black
 	colorParam := r.URL.Query().Get("color")
 	if colorParam != "" {
-		if len(colorParam) != 7 || string(colorParam[0]) != "#" {
+		if !reColorParam.MatchString(colorParam) {
 			handleBadRequest(w, r, errBadColor)
 			return
 		}

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -3,6 +3,7 @@ package http
 import (
 	"errors"
 	"fmt"
+	"image/color"
 	"image/png"
 	"math"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/BattlesnakeOfficial/exporter/engine"
 	"github.com/BattlesnakeOfficial/exporter/media"
+	"github.com/BattlesnakeOfficial/exporter/parse"
 	"github.com/BattlesnakeOfficial/exporter/render"
 )
 
@@ -29,6 +31,9 @@ const maxGIFResolution = 504 * 504
 
 // allowedPixelsPerSquare is a list of resolutions that the API will allow.
 var allowedPixelsPerSquare = []int{10, 20, 30, 40}
+
+var errBadRequest = fmt.Errorf("bad request")
+var errBadColor = fmt.Errorf("color parameter should have the format #FFFFFF")
 
 func handleVersion(w http.ResponseWriter, r *http.Request) {
 	version := os.Getenv("APP_VERSION")
@@ -43,7 +48,6 @@ var reAvatarCustomizations = regexp.MustCompile(`(?P<key>[a-z-]{1,32}):(?P<value
 
 func handleAvatar(w http.ResponseWriter, r *http.Request) {
 	subPath := strings.TrimPrefix(r.URL.Path, "/avatars")
-	errBadRequest := fmt.Errorf("bad request")
 	avatarSettings := render.AvatarSettings{}
 
 	// Extract width, height, and filetype
@@ -141,6 +145,68 @@ func handleAvatar(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "image/svg+xml")
 	fmt.Fprint(w, avatarSVG)
+}
+
+var reCustomizationParam = regexp.MustCompile(`^[A-Za-z-0-9#]{1,32}$`)
+
+func handleCustomization(w http.ResponseWriter, r *http.Request) {
+	customizationType := pat.Param(r, "type")
+	customizationName := pat.Param(r, "name")
+	ext := pat.Param(r, "ext")
+
+	if ext != "svg" {
+		handleBadRequest(w, r, errBadRequest)
+		return
+	}
+
+	if customizationType != "head" && customizationType != "tail" {
+		handleBadRequest(w, r, errBadRequest)
+		return
+	}
+
+	if !reCustomizationParam.MatchString(customizationName) {
+		handleBadRequest(w, r, errBadRequest)
+		return
+	}
+
+	var customizationColor color.Color = color.Black
+	colorParam := r.URL.Query().Get("color")
+	if colorParam != "" {
+		if len(colorParam) != 7 || string(colorParam[0]) != "#" {
+			handleBadRequest(w, r, errBadColor)
+			return
+		}
+
+		customizationColor = parse.HexColor(colorParam)
+	}
+
+	flippedParam := r.URL.Query().Get("flipped") != ""
+
+	var svg string
+	var err error
+	var shouldFlip bool
+	switch customizationType {
+	case "head":
+		svg, err = media.GetHeadSVG(customizationName)
+		shouldFlip = flippedParam
+	case "tail":
+		svg, err = media.GetTailSVG(customizationName)
+		shouldFlip = !flippedParam
+	}
+
+	if err != nil {
+		if err == media.ErrNotFound {
+			handleError(w, r, err, http.StatusNotFound)
+		} else {
+			handleError(w, r, err, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	svg = media.CustomizeSnakeSVG(svg, customizationColor, shouldFlip)
+
+	w.Header().Set("Content-Type", "image/svg+xml")
+	fmt.Fprint(w, svg)
 }
 
 func handleASCIIFrame(w http.ResponseWriter, r *http.Request) {

--- a/http/server.go
+++ b/http/server.go
@@ -34,6 +34,8 @@ func NewServer() *Server {
 	// Export routes
 	mux.HandleFunc(pat.Get("/avatars/*"), withCaching(handleAvatar))
 
+	mux.HandleFunc(pat.Get("/customizations/:type/:name.:ext"), withCaching(handleCustomization))
+
 	mux.HandleFunc(pat.Get("/games/:game/gif"), withCaching(handleGIFGame))
 	mux.HandleFunc(pat.Get("/games/:game/frames/:frame/ascii"), withCaching(handleASCIIFrame))
 	mux.HandleFunc(pat.Get("/games/:game/frames/:frame/gif"), withCaching(handleGIFFrame))

--- a/media/api.go
+++ b/media/api.go
@@ -45,7 +45,7 @@ func getMediaResource(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if response.StatusCode == http.StatusNotFound {
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusForbidden {
 		return "", ErrNotFound
 	}
 	if response.StatusCode != 200 {

--- a/media/media_internal_test.go
+++ b/media/media_internal_test.go
@@ -208,24 +208,28 @@ func TestColorToHex6(t *testing.T) {
 func TestCustomiseSVG(t *testing.T) {
 
 	// simple
-	customized := customiseSnakeSVG("<svg></svg>", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
+	customized := CustomizeSnakeSVG("<svg></svg>", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
 	require.Equal(t, `<svg fill="#00ccaa"></svg>`, customized)
 
 	// make sure it doesn't panic with strange/bad inputs
-	customiseSnakeSVG("", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
-	customiseSnakeSVG("afe9*#@(#f2038208", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
-	customiseSnakeSVG("<svg", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
-	customiseSnakeSVG("<svg><foo></>", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
-	customiseSnakeSVG("<</>>>//", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
-	customiseSnakeSVG("<html></html>", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
+	CustomizeSnakeSVG("", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
+	CustomizeSnakeSVG("afe9*#@(#f2038208", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
+	CustomizeSnakeSVG("<svg", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
+	CustomizeSnakeSVG("<svg><foo></>", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
+	CustomizeSnakeSVG("<</>>>//", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
+	CustomizeSnakeSVG("<html></html>", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
 
 	// nested
-	customized = customiseSnakeSVG("<svg><svg></svg></svg>", color.RGBA{0x00, 0xcc, 0xaa, 0xff})
+	customized = CustomizeSnakeSVG("<svg><svg></svg></svg>", color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
 	require.Equal(t, `<svg fill="#00ccaa"><svg></svg></svg>`, customized, "nested SVG tags should be ignored")
 
 	// use a real head
-	customized = customiseSnakeSVG(headSVG, color.RGBA{0x00, 0xcc, 0xaa, 0xff})
+	customized = CustomizeSnakeSVG(headSVG, color.RGBA{0x00, 0xcc, 0xaa, 0xff}, false)
 	require.Contains(t, customized, `<svg id="root" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" fill="#00ccaa">`)
+
+	// flip horizontal
+	customized = CustomizeSnakeSVG(headSVG, color.RGBA{0x00, 0xcc, 0xaa, 0xff}, true)
+	require.Contains(t, customized, `<svg id="root" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" fill="#00ccaa" transform="scale(-1, 1) translate(-100, 0)">`)
 }
 
 const headSVG = `<svg id="root" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Example endpoints:
```
https://exporter.battlesnake.com/customizations/head/silly.svg?color=%23ff0000
https://exporter.battlesnake.com/customizations/tail/fish.svg?color=%23ff0000
```

Flipping them horizontally:
```
https://exporter.battlesnake.com/customizations/head/silly.svg?flipped=1
https://exporter.battlesnake.com/customizations/tail/fish.svg?flipped=1
```